### PR TITLE
Set request body limit to a big enough default so we do not error on …

### DIFF
--- a/render.js
+++ b/render.js
@@ -19,7 +19,7 @@ var argv = require('yargs')
 morgan.token('file', function(req, res){ return path.basename(req.body.path_to_source); });
 
 var app = express();
-app.use(bodyParser.json());
+app.use(bodyParser.json({limit: '50mb'}));
 app.use(morgan('[:date[iso]] :method :url :status :response-time ms - :file :res[content-length]'));
 
 // Component cache living in global scope


### PR DESCRIPTION
…large rendering requests.

When asking the rendering service to render pages with a lot of data (listings, indices, etc.), it fails with:

```
> react-service --debug --watch

Started server at http://127.0.0.1:63578
[2015-11-15T11:19:24.654Z] Error: request entity too large
```

According to the discussion at http://stackoverflow.com/questions/19917401/node-js-express-request-entity-too-large, it seems setting a large default is the way to go. We can change this to an environment variable with a default if you reckon that is a better way forward. 

