### PR TITLE
Resolve static content at STATIC_ROOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+### 1.x.x (Unreleased)
+
+Python package bumped to 1.1.0:
+    - Attempt to resolve static content at STATIC_ROOT where content should have
+      been collected.
+
 ### 1.3.0
 
 Update React to version 16.8.6

--- a/react_render/django/render.py
+++ b/react_render/django/render.py
@@ -47,8 +47,14 @@ def render_component(path_to_source, props=None, to_static_markup=False, json_en
             except ValueError:
                 # Couldn't find it.
                 pass
-        # Now resolve it to the absolute path using the finders
-        path_to_source = find_static(path_to_source) or path_to_source
+
+        # first, attempt to resolve at STATIC_ROOT if the file was collected
+        abs_path = os.path.join(settings.STATIC_ROOT, path_to_source)
+        if os.path.exists(abs_path):
+            path_to_source = abs_path
+        else:
+            # Otherwise, resolve it using finders
+            path_to_source = find_static(path_to_source) or path_to_source
 
     if json_encoder is None:
         json_encoder = DjangoJSONEncoder().encode

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = '1.0.0'
+VERSION = '1.1.0'
 
 setup(
     name='react-render-client',

--- a/tests/test_functionality.py
+++ b/tests/test_functionality.py
@@ -10,12 +10,12 @@ from react_render.exceptions import ComponentRenderingError, ComponentSourceFile
 COMPONENT_ROOT = os.path.join(os.path.dirname(__file__), 'components')
 
 PATH_TO_HELLO_WORLD_COMPONENT_JS = os.path.join(COMPONENT_ROOT, 'HelloWorldPlain.js')
-PATH_TO_HELLO_WORLD_COMPONENT_JSX = os.path.join(COMPONENT_ROOT, 'HelloWorld.js')
-PATH_TO_HELLO_WORLD_WRAPPER_COMPONENT = os.path.join(COMPONENT_ROOT, 'HelloWorldWrapper.js')
-PATH_TO_ERROR_THROWING_COMPONENT = os.path.join(COMPONENT_ROOT, 'ErrorThrowingComponent.js')
-PATH_TO_SYNTAX_ERROR_COMPONENT = os.path.join(COMPONENT_ROOT, 'SyntaxErrorComponent.js')
-PATH_TO_ES6 = os.path.join(COMPONENT_ROOT, 'ES6Test.js')
-PATH_TO_STATIC_FILE_FINDER_COMPONENT = 'test_app/StaticFileFinderComponent.js'
+PATH_TO_HELLO_WORLD_COMPONENT_JSX = os.path.join(COMPONENT_ROOT, 'HelloWorld.jsx')
+PATH_TO_HELLO_WORLD_WRAPPER_COMPONENT = os.path.join(COMPONENT_ROOT, 'HelloWorldWrapper.jsx')
+PATH_TO_ERROR_THROWING_COMPONENT = os.path.join(COMPONENT_ROOT, 'ErrorThrowingComponent.jsx')
+PATH_TO_SYNTAX_ERROR_COMPONENT = os.path.join(COMPONENT_ROOT, 'SyntaxErrorComponent.jsx')
+PATH_TO_ES6 = os.path.join(COMPONENT_ROOT, 'ES6Test.jsx')
+PATH_TO_STATIC_FILE_FINDER_COMPONENT = 'test_app/StaticFileFinderComponent.jsx'
 
 
 class TestDjangoReact(unittest.TestCase):
@@ -59,7 +59,7 @@ class TestDjangoReact(unittest.TestCase):
         self.assertNotEqual(markup, '<span>Hello world!</span>')
         self.assertIn('Hello ', markup)
         self.assertIn('world!', markup)
-        
+
     def test_render_component_returns_a_rendered_component(self):
         component = render_component(
             PATH_TO_HELLO_WORLD_COMPONENT_JSX,


### PR DESCRIPTION
Server Render doesn't resolve hashed static content at STATIC_ROOT - this changes that.

The tests are pretty badly broken by the way, should probably get it onto circle or gh. I couldn't get them running on my local properly.